### PR TITLE
Add options hash to survey_responses

### DIFF
--- a/lib/surveygizmo/client/survey_response.rb
+++ b/lib/surveygizmo/client/survey_response.rb
@@ -6,8 +6,8 @@ module Surveygizmo
       
       # List all survey responses for a given survey
       # @param survey_id [Integer, String] Specify the survey to the responses to get
-      def survey_responses(survey_id)
-        get("survey/#{survey_id}/surveyresponse")
+      def survey_responses(survey_id, options = {})
+        get("survey/#{survey_id}/surveyresponse", options)
       end
       
       # Returns survey response details for a given id


### PR DESCRIPTION
Survey Gizmo's API returns 50 results by default. Adding an options hash to survey_responses allows the user to finely tune their results by using a combination of resultsperpage and page.
