### PR TITLE
Middleware to Raise Errors and Create Response

### DIFF
--- a/lib/surveygizmo/client.rb
+++ b/lib/surveygizmo/client.rb
@@ -1,5 +1,4 @@
 require 'surveygizmo/api'
-require 'surveygizmo/configurable'
 
 module Surveygizmo
   # Wrapper for the Surveygizmo REST API
@@ -20,7 +19,6 @@ module Surveygizmo
     require 'surveygizmo/client/survey_question'
     require 'surveygizmo/client/survey_statistic'
 
-    include Surveygizmo::Configurable
     include Surveygizmo::Client::Account
     include Surveygizmo::Client::AccountUser
     include Surveygizmo::Client::Contact

--- a/lib/surveygizmo/configurable.rb
+++ b/lib/surveygizmo/configurable.rb
@@ -3,7 +3,7 @@ require 'surveygizmo/default'
 module Surveygizmo
   module Configurable
     attr_writer :username, :password
-    attr_accessor :endpoint, :user_agent
+    attr_accessor :endpoint, :user_agent, :connection_options, :middleware
 
     class << self
       def keys
@@ -11,7 +11,9 @@ module Surveygizmo
           :username,
           :password,
           :endpoint,
-          :user_agent
+          :user_agent,
+          :connection_options,
+          :middleware
         ]
       end
     end

--- a/lib/surveygizmo/connection.rb
+++ b/lib/surveygizmo/connection.rb
@@ -6,20 +6,7 @@ module Surveygizmo
   module Connection
 
     private
-
-      def connection(temp_api_endpoint=nil)
-        options = {
-          :headers => { 'Accept' => 'application/json', 'User-Agent' => @user_agent },
-          :ssl => { :verify => false }
-        }
-
-        if credentials?
-          authentication = auth_query_hash
-          options[:params] = authentication
-        end
-
-        options[:url] = temp_api_endpoint ? temp_api_endpoint : @endpoint
-
+      def connection(options= {})
         Faraday.new(options) do |builder|
           builder.use Faraday::Request::UrlEncoded
           builder.use Faraday::Response::Mashify
@@ -28,8 +15,5 @@ module Surveygizmo
         end
       end
 
-      def auth_query_hash
-        { :'user:md5' => "#{credentials[:username]}:#{Digest::MD5.hexdigest(credentials[:password])}" }
-      end
   end
 end

--- a/lib/surveygizmo/connection.rb
+++ b/lib/surveygizmo/connection.rb
@@ -1,4 +1,3 @@
-require 'faraday_middleware'
 require 'digest/md5'
 
 module Surveygizmo
@@ -7,13 +6,7 @@ module Surveygizmo
 
     private
       def connection(options= {})
-        Faraday.new(options) do |builder|
-          builder.use Faraday::Request::UrlEncoded
-          builder.use Faraday::Response::Mashify
-          builder.use Faraday::Response::ParseJson
-          builder.adapter(:net_http)
-        end
+        @connection ||= Faraday.new(@endpoint, @connection_options.merge(:builder => @middleware))
       end
-
   end
 end

--- a/lib/surveygizmo/default.rb
+++ b/lib/surveygizmo/default.rb
@@ -18,12 +18,16 @@ module Surveygizmo
       &Proc.new do |builder|
         # Convert request params to "www-form-urlencoded"
         builder.use Faraday::Request::UrlEncoded
+
         # Converts parsed response bodies to a Surveygizmo::Response
         builder.use Surveygizmo::Response::ParseSurveygizmoResponse
+
         # Handle server responses using Surveygizmo::Error
         builder.use Surveygizmo::Response::RaiseError, Surveygizmo::Error
+
         # Parse JSON response bodies using MultiJson
         builder.use Faraday::Response::ParseJson
+
         # Set Faraday's HTTP adapter
         builder.adapter(:net_http)
       end

--- a/lib/surveygizmo/default.rb
+++ b/lib/surveygizmo/default.rb
@@ -2,8 +2,8 @@ require 'surveygizmo/configurable'
 
 module Surveygizmo
   module Default
-    ENDPOINT   = 'https://restapi.surveygizmo.com/v2/'
-    USER_AGENT = "Surveygizmo Ruby Gem #{Surveygizmo::VERSION}"
+    ENDPOINT   = 'https://restapi.surveygizmo.com/v2/' unless defined? ENDPOINT
+    USER_AGENT = "Surveygizmo Ruby Gem #{Surveygizmo::VERSION}" unless defined? USER_AGENT
 
     class << self
       def options

--- a/lib/surveygizmo/default.rb
+++ b/lib/surveygizmo/default.rb
@@ -1,5 +1,7 @@
 require 'surveygizmo/configurable'
 require 'faraday_middleware'
+require 'surveygizmo/response'
+require 'surveygizmo/response/raise_error'
 
 module Surveygizmo
   module Default
@@ -17,6 +19,8 @@ module Surveygizmo
         builder.use Faraday::Request::UrlEncoded
         # Converts parsed response bodies to a Hashie::Mash
         builder.use Faraday::Response::Mashify
+        # Handle server responses using Surveygizmo::Error
+        builder.use Surveygizmo::Response::RaiseError, Surveygizmo::Error
         # Parse JSON response bodies using MultiJson
         builder.use Faraday::Response::ParseJson
         # Set Faraday's HTTP adapter

--- a/lib/surveygizmo/default.rb
+++ b/lib/surveygizmo/default.rb
@@ -13,9 +13,13 @@ module Surveygizmo
     } unless defined? CONNECTION_OPTIONS
     MIDDLEWARE = Faraday::Builder.new(
       &Proc.new do |builder|
+        # Convert request params to "www-form-urlencoded"
         builder.use Faraday::Request::UrlEncoded
+        # Converts parsed response bodies to a Hashie::Mash
         builder.use Faraday::Response::Mashify
+        # Parse JSON response bodies using MultiJson
         builder.use Faraday::Response::ParseJson
+        # Set Faraday's HTTP adapter
         builder.adapter(:net_http)
       end
     )

--- a/lib/surveygizmo/default.rb
+++ b/lib/surveygizmo/default.rb
@@ -1,9 +1,24 @@
 require 'surveygizmo/configurable'
+require 'faraday_middleware'
 
 module Surveygizmo
   module Default
     ENDPOINT   = 'https://restapi.surveygizmo.com/v2/' unless defined? ENDPOINT
     USER_AGENT = "Surveygizmo Ruby Gem #{Surveygizmo::VERSION}" unless defined? USER_AGENT
+    CONNECTION_OPTIONS = {
+      :headers => { 
+        :accept => 'application/json', 
+        :user_agent => USER_AGENT },
+      :ssl => { :verify => false }
+    } unless defined? CONNECTION_OPTIONS
+    MIDDLEWARE = Faraday::Builder.new(
+      &Proc.new do |builder|
+        builder.use Faraday::Request::UrlEncoded
+        builder.use Faraday::Response::Mashify
+        builder.use Faraday::Response::ParseJson
+        builder.adapter(:net_http)
+      end
+    )
 
     class << self
       def options
@@ -24,6 +39,14 @@ module Surveygizmo
 
       def user_agent
         USER_AGENT
+      end
+
+      def connection_options
+        CONNECTION_OPTIONS
+      end
+
+      def middleware
+        MIDDLEWARE
       end
     end
 

--- a/lib/surveygizmo/default.rb
+++ b/lib/surveygizmo/default.rb
@@ -2,6 +2,7 @@ require 'surveygizmo/configurable'
 require 'faraday_middleware'
 require 'surveygizmo/response'
 require 'surveygizmo/response/raise_error'
+require 'surveygizmo/response/parse_surveygizmo_response'
 
 module Surveygizmo
   module Default
@@ -17,6 +18,8 @@ module Surveygizmo
       &Proc.new do |builder|
         # Convert request params to "www-form-urlencoded"
         builder.use Faraday::Request::UrlEncoded
+        # Converts parsed response bodies to a Surveygizmo::Response
+        builder.use Surveygizmo::Response::ParseSurveygizmoResponse
         # Handle server responses using Surveygizmo::Error
         builder.use Surveygizmo::Response::RaiseError, Surveygizmo::Error
         # Parse JSON response bodies using MultiJson

--- a/lib/surveygizmo/default.rb
+++ b/lib/surveygizmo/default.rb
@@ -17,8 +17,6 @@ module Surveygizmo
       &Proc.new do |builder|
         # Convert request params to "www-form-urlencoded"
         builder.use Faraday::Request::UrlEncoded
-        # Converts parsed response bodies to a Hashie::Mash
-        builder.use Faraday::Response::Mashify
         # Handle server responses using Surveygizmo::Error
         builder.use Surveygizmo::Response::RaiseError, Surveygizmo::Error
         # Parse JSON response bodies using MultiJson

--- a/lib/surveygizmo/default.rb
+++ b/lib/surveygizmo/default.rb
@@ -1,7 +1,7 @@
 require 'surveygizmo/configurable'
 require 'faraday_middleware'
 require 'surveygizmo/response'
-require 'surveygizmo/response/raise_error'
+require 'surveygizmo/response/raise_error_on_failed_request'
 require 'surveygizmo/response/parse_surveygizmo_response'
 
 module Surveygizmo
@@ -22,8 +22,8 @@ module Surveygizmo
         # Converts parsed response bodies to a Surveygizmo::Response
         builder.use Surveygizmo::Response::ParseSurveygizmoResponse
 
-        # Handle server responses using Surveygizmo::Error
-        builder.use Surveygizmo::Response::RaiseError, Surveygizmo::Error
+        # Raise Errors on Failed Requests from Surveygizmo with Surveygizmo::Error
+        builder.use Surveygizmo::Response::RaiseErrorOnFailedRequest, Surveygizmo::Error
 
         # Parse JSON response bodies using MultiJson
         builder.use Faraday::Response::ParseJson

--- a/lib/surveygizmo/request.rb
+++ b/lib/surveygizmo/request.rb
@@ -15,19 +15,13 @@ module Surveygizmo
 
     # Perform an HTTP request
     def request(method, path, options, temp_api_endpoint=nil)
-      connection_options = {
-        :headers => { 'Accept' => 'application/json', 'User-Agent' => @user_agent },
-        :ssl => { :verify => false }
-      }
-
       if credentials?
         authentication = auth_query_hash
-        connection_options[:params] = authentication
+        connection.params.merge!(authentication)
       end
 
-      connection_options[:url] = temp_api_endpoint ? temp_api_endpoint : @endpoint
-
-      response = connection(connection_options).send(method) do |request|
+      connection.url_prefix = temp_api_endpoint || @endpoint
+      response = connection.send(method) do |request|
         convert_hash_filter_params!(options)
         case method.to_sym
         when :get, :delete

--- a/lib/surveygizmo/request.rb
+++ b/lib/surveygizmo/request.rb
@@ -33,12 +33,6 @@ module Surveygizmo
       end
 
       response = Response.new(response)
-
-      if response.failed?
-        raise Error.new(response.error_code, response.error_message)
-      else
-        response
-      end
     end
 
     def convert_hash_filter_params! options

--- a/lib/surveygizmo/request.rb
+++ b/lib/surveygizmo/request.rb
@@ -32,7 +32,7 @@ module Surveygizmo
         end
       end
 
-      response = Response.new(response.body)
+      response.body
     end
 
     def convert_hash_filter_params! options

--- a/lib/surveygizmo/request.rb
+++ b/lib/surveygizmo/request.rb
@@ -32,7 +32,7 @@ module Surveygizmo
         end
       end
 
-      response = Response.new(response)
+      response = Response.new(response.body)
     end
 
     def convert_hash_filter_params! options

--- a/lib/surveygizmo/response.rb
+++ b/lib/surveygizmo/response.rb
@@ -13,7 +13,7 @@ module Surveygizmo
     end
 
     # Build meta data access methods.
-    [:result_ok, :total_count, :page, :total_pages, :results_per_page].each do |field|
+    [:total_count, :page, :total_pages, :results_per_page].each do |field|
       define_method field do
         @response.body.send(field).to_i
       end

--- a/lib/surveygizmo/response.rb
+++ b/lib/surveygizmo/response.rb
@@ -4,6 +4,12 @@ module Surveygizmo
     attr_reader :response
     attr_reader :data
 
+    class << self
+      attr_accessor :mash_class
+    end
+
+    self.mash_class = Hashie::Mash
+
     def initialize(response)
       @response = mashify(response)
       @data     = @response.data
@@ -28,15 +34,10 @@ module Surveygizmo
       (self.data == other.data) && (self.result == other.result)
     end
 
-    private
-    def mash_class
-      Hashie::Mash
-    end
-
     def mashify(body)
       case body
       when Hash
-        mash_class.new(body)
+        self.class.mash_class.new(body)
       when Array
         body.map { |item| mashify(item) }
       else

--- a/lib/surveygizmo/response.rb
+++ b/lib/surveygizmo/response.rb
@@ -1,11 +1,12 @@
+require 'hashie'
 module Surveygizmo
   class Response
     attr_reader :response
     attr_reader :data
 
     def initialize(response)
-      @response = response
-      @data     = response.body.data
+      @response = parse(response)
+      @data     = @response.data
     end
 
     def method_missing(name, *arguments, &block)
@@ -15,16 +16,32 @@ module Surveygizmo
     # Build meta data access methods.
     [:total_count, :page, :total_pages, :results_per_page].each do |field|
       define_method field do
-        @response.body.send(field).to_i
+        @response.send(field).to_i
       end
     end
 
     def success?
-      @response.body.result_ok
+      @response.result_ok
     end
 
     def ==(other)
       (self.data == other.data) && (self.result == other.result)
+    end
+
+    private
+    def mash_class
+      Hashie::Mash
+    end
+
+    def parse(body)
+      case body
+      when Hash
+        mash_class.new(body)
+      when Array
+        body.map { |item| parse(item) }
+      else
+        body
+      end
     end
   end
 end

--- a/lib/surveygizmo/response.rb
+++ b/lib/surveygizmo/response.rb
@@ -12,14 +12,6 @@ module Surveygizmo
       @data.send(name, *arguments, &block)
     end
 
-    def error_code
-      @response.body.code.to_i
-    end
-
-    def error_message
-      @response.body.message
-    end
-
     # Build meta data access methods.
     [:result_ok, :total_count, :page, :total_pages, :results_per_page].each do |field|
       define_method field do
@@ -29,10 +21,6 @@ module Surveygizmo
 
     def success?
       @response.body.result_ok
-    end
-
-    def failed?
-      !success?
     end
 
     def ==(other)

--- a/lib/surveygizmo/response.rb
+++ b/lib/surveygizmo/response.rb
@@ -5,7 +5,7 @@ module Surveygizmo
     attr_reader :data
 
     def initialize(response)
-      @response = parse(response)
+      @response = mashify(response)
       @data     = @response.data
     end
 
@@ -33,12 +33,12 @@ module Surveygizmo
       Hashie::Mash
     end
 
-    def parse(body)
+    def mashify(body)
       case body
       when Hash
         mash_class.new(body)
       when Array
-        body.map { |item| parse(item) }
+        body.map { |item| mashify(item) }
       else
         body
       end

--- a/lib/surveygizmo/response/parse_surveygizmo_response.rb
+++ b/lib/surveygizmo/response/parse_surveygizmo_response.rb
@@ -1,0 +1,16 @@
+require 'faraday'
+require 'surveygizmo/response'
+ 
+module Surveygizmo
+  class Response::ParseSurveygizmoResponse < Faraday::Response::Middleware
+    class << self
+      attr_accessor :response_class
+    end
+ 
+    self.response_class = Surveygizmo::Response
+ 
+    def parse(body)
+      self.class.response_class.new(body)
+    end
+  end
+end

--- a/lib/surveygizmo/response/raise_error.rb
+++ b/lib/surveygizmo/response/raise_error.rb
@@ -1,0 +1,22 @@
+require 'faraday'
+require 'surveygizmo/error'
+
+module Surveygizmo
+  class Response::RaiseError < Faraday::Response::Middleware
+
+    def on_complete(env)
+      if env[:body] && ! env[:body]["result_ok"]
+        error_code = env[:body]["code"].to_i
+        message = env[:body]["message"]
+
+        raise @klass.new(error_code, message)
+      end
+    end
+
+    def initialize(app, klass)
+      @klass = klass
+      super(app)
+    end
+
+  end
+end

--- a/lib/surveygizmo/response/raise_error_on_failed_request.rb
+++ b/lib/surveygizmo/response/raise_error_on_failed_request.rb
@@ -2,7 +2,7 @@ require 'faraday'
 require 'surveygizmo/error'
 
 module Surveygizmo
-  class Response::RaiseError < Faraday::Response::Middleware
+  class Response::RaiseErrorOnFailedRequest < Faraday::Response::Middleware
 
     def on_complete(env)
       if env[:body] && ! env[:body]["result_ok"]


### PR DESCRIPTION
Expanding the usage of the Faraday Middleware, these changes are a refactors of raising errors and  Surveygizmo Response creations. Both are now completed in a middleware.

This change can lead to custom errors to be raised as well as replacing the JSON parser to MultiJSON.
## Comments to Note

The Response Class is by far the hairiest decision made. At first, the class was a subclass of `Hashie::Mash`, but I ran into issues with Ruby's enum functions such as each. Its great to have the response as a mash. Maybe considerations could be made to make a wrapper around a Mashify-ed Response that links the enumerable functions to `data`. 
